### PR TITLE
Define group for customize

### DIFF
--- a/abl-mode.el
+++ b/abl-mode.el
@@ -31,6 +31,10 @@
 ;; <<--------- The necessary minor-mode stuff  ---------->>
 (eval-when-compile (require 'cl))
 
+(defgroup abl-mode nil
+  "Python TDD minor mode."
+  :group 'python)
+
 (defvar abl-mode nil
   "Mode variable for abl-mode")
 (make-variable-buffer-local 'abl-mode)


### PR DESCRIPTION
This change also fixes some byte-compile warnings.

```
abl-mode.el:80:1:Warning: defcustom for `abl-mode-ve-activate-command' fails
    to specify containing group
abl-mode.el:80:1:Warning: defcustom for `abl-mode-ve-activate-command' fails
    to specify containing group
abl-mode.el:84:1:Warning: defcustom for `abl-mode-ve-create-command' fails to
    specify containing group
abl-mode.el:84:1:Warning: defcustom for `abl-mode-ve-create-command' fails to
    specify containing group
abl-mode.el:88:1:Warning: defcustom for `abl-mode-test-command' fails to
    specify containing group
abl-mode.el:88:1:Warning: defcustom for `abl-mode-test-command' fails to
    specify containing group
abl-mode.el:92:1:Warning: defcustom for `abl-mode-branch-shell-prefix' fails
    to specify containing group
abl-mode.el:92:1:Warning: defcustom for `abl-mode-branch-shell-prefix' fails
    to specify containing group
abl-mode.el:96:1:Warning: defcustom for `abl-mode-check-and-activate-ve' fails
    to specify containing group
abl-mode.el:96:1:Warning: defcustom for `abl-mode-check-and-activate-ve' fails
    to specify containing group
abl-mode.el:100:1:Warning: defcustom for `abl-mode-ve-base-dir' fails to
    specify containing group
abl-mode.el:100:1:Warning: defcustom for `abl-mode-ve-base-dir' fails to
    specify containing group
abl-mode.el:104:1:Warning: defcustom for `abl-mode-install-command' fails to
    specify containing group
abl-mode.el:104:1:Warning: defcustom for `abl-mode-install-command' fails to
    specify containing group
abl-mode.el:108:1:Warning: defcustom for `abl-mode-test-file-regexp' fails to
    specify containing group
abl-mode.el:108:1:Warning: defcustom for `abl-mode-test-file-regexp' fails to
    specify containing group
abl-mode.el:112:1:Warning: defcustom for
    `abl-mode-test-path-module-class-separator' fails to specify containing
    group
abl-mode.el:112:1:Warning: defcustom for
    `abl-mode-test-path-module-class-separator' fails to specify containing
    group
abl-mode.el:116:1:Warning: defcustom for `abl-mode-code-file-tests-regexps'
    fails to specify containing group
abl-mode.el:116:1:Warning: defcustom for `abl-mode-code-file-tests-regexps'
    fails to specify containing group
abl-mode.el:121:1:Warning: defcustom for `abl-mode-end-testrun-re' fails to
    specify containing group
abl-mode.el:121:1:Warning: defcustom for `abl-mode-end-testrun-re' fails to
    specify containing group
```